### PR TITLE
Add centralized configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,19 @@ Projet domotique open source basé sur ESP32 pour piloter automatiquement le cha
 
 ---
 
+## 🔧 Configuration
+
+Les paramètres modifiables (Wi-Fi, broches GPIO, etc.) se trouvent dans `src/config.h`.
+Avant de compiler, éditez ce fichier pour y renseigner votre SSID, mot de passe
+et éventuellement la température ou l'heure cible.
+
+---
+
 ## 🧱 Arborescence du projet
 chauffe_piscine_esp32/
 ├── src/
 │ ├── main.cpp
+│ ├── config.h
 │ ├── sensors.cpp / .h
 │ ├── chauffage.cpp / .h
 │ ├── web.cpp / .h

--- a/src/chauffage.cpp
+++ b/src/chauffage.cpp
@@ -2,8 +2,7 @@
 #include "sensors.h"
 #include "FS.h"
 #include "SPIFFS.h"
-
-static constexpr uint8_t SERVO_PIN = 14; // GPIO controlling the switch
+#include "config.h"
 
 void ChauffageManager::begin() {
     servo.attach(SERVO_PIN);

--- a/src/chauffage.h
+++ b/src/chauffage.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <Servo.h>
+#include "config.h"
 
 class SensorsManager; // forward declaration
 
@@ -31,7 +32,7 @@ private:
     Servo servo;
     bool heating = false;
     Mode mode = AUTO_ADULTE;
-    float targetTemp = 33.0f; // default target temp for adult mode
+    float targetTemp = TARGET_TEMPERATURE; // default target temp for adult mode
     unsigned long lastLog = 0;
 };
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,21 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+// Wi-Fi credentials
+static const char* WIFI_SSID = "YOUR_SSID";
+static const char* WIFI_PASS = "YOUR_PASSWORD";
+
+// Target temperature when using manual set (float)
+static constexpr float TARGET_TEMPERATURE = 33.0f;
+
+// Target time for heating start (HH:MM)
+static const char* TARGET_TIME = "18:00";
+
+// GPIO pin numbers
+static constexpr uint8_t SERVO_PIN = 14;
+static constexpr uint8_t ONE_WIRE_PIN = 4;
+
+// Optional API key for future features
+static const char* API_KEY = "";
+
+#endif // CONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "chauffage.h"
 #include "web.h"
 #include "utils.h"
+#include "config.h"
 #include <WiFi.h>
 #include <FS.h>
 #include <SPIFFS.h>
@@ -13,8 +14,6 @@
 #define DEBUG_MODE 1
 #endif
 
-static const char* WIFI_SSID = "YOUR_SSID";
-static const char* WIFI_PASS = "YOUR_PASSWORD";
 
 SensorsManager sensors;
 ChauffageManager chauffage(&sensors);

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <OneWire.h>
 #include <DallasTemperature.h>
+#include "config.h"
 
 // Manages the DS18B20 sensors (water and air)
 class SensorsManager {
@@ -15,7 +16,7 @@ public:
     float getAirTemp() const { return airTemp; }
 
 private:
-    static constexpr uint8_t ONE_WIRE_BUS = 4; // GPIO pin for DS18B20 bus
+    static constexpr uint8_t ONE_WIRE_BUS = ONE_WIRE_PIN; // GPIO pin from config
 
     OneWire oneWire{ONE_WIRE_BUS};
     DallasTemperature ds{&oneWire};


### PR DESCRIPTION
## Summary
- create `config.h` for all changeable parameters
- include new header across project
- document configuration file location

## Testing
- `python3 -m platformio run` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68677cb8f3508329a7df4a306384ccea