### PR TITLE
Add serial port config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Les paramètres modifiables (Wi-Fi, broches GPIO, etc.) se trouvent dans `src/co
 Avant de compiler, éditez ce fichier pour y renseigner votre SSID, mot de passe
 et éventuellement la température ou l'heure cible.
 
+Si vous utilisez VS Code avec PlatformIO, vous pouvez spécifier le port série à
+utiliser dans `platformio.ini` via les directives `upload_port` et
+`monitor_port`. Par exemple :
+
+```ini
+upload_port = /dev/cu.usbserial-0001
+monitor_port = /dev/cu.usbserial-0001
+```
+
 ---
 
 ## 🧱 Arborescence du projet

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,7 +3,9 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
-lib_deps = 
+upload_port = /dev/cu.usbserial-0001
+monitor_port = /dev/cu.usbserial-0001
+lib_deps =
   onewire
   DallasTemperature
   ESP32Servo


### PR DESCRIPTION
## Summary
- specify `upload_port` and `monitor_port` to use `/dev/cu.usbserial-0001`
- document serial port configuration in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867a8a57730832999378b3f4a5d38c1