### PR TITLE
Fix missing includes for ESP32Servo and Utils

### DIFF
--- a/src/chauffage.h
+++ b/src/chauffage.h
@@ -2,7 +2,7 @@
 #define CHAUFFAGE_H
 
 #include <Arduino.h>
-#include <Servo.h>
+#include <ESP32Servo.h>
 
 #include "config.h"
 #include "utils.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,8 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <Arduino.h>
+
 // Miscellaneous helper utilities
 class Utils {
 public:


### PR DESCRIPTION
## Summary
- include Arduino headers in Utils
- use the ESP32Servo library header

## Testing
- `platformio run` *(fails: unable to install espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_6867aca2c1f88329a08a4cde6549bda5