### PR TITLE
Add dynamic web interface with schedule and graphs

### DIFF
--- a/src/web.cpp
+++ b/src/web.cpp
@@ -25,15 +25,18 @@ void WebManager::handleClient() {
 
 void WebManager::handleRoot() {
     String page;
+    ChauffageManager::Schedule sch = chauffage->getSchedule();
     page += "<!DOCTYPE html><html lang='fr'><head><meta charset='utf-8'>";
     page += "<meta name='viewport' content='width=device-width,initial-scale=1'>";
     page += "<title>Chauffe Piscine</title>";
+    page += "<script src='https://cdn.jsdelivr.net/npm/chart.js'></script>";
+    page += "<script src='https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns'></script>";
     page += "<style>body{background:#fff;color:#000;font-family:Arial,Helvetica,sans-serif;margin:0;padding:1rem;}";
-    page += "form{max-width:400px;margin:auto;}fieldset{border:1px solid #000;padding:1rem;margin-bottom:1rem;}";
-    page += "label{display:block;margin:.5rem 0;}#manual button{margin-right:.5rem;}";
+    page += "fieldset{border:1px solid #000;margin-bottom:.5rem;padding:.5rem;}label{display:block;margin:.25rem 0;}";
+    page += "#chart{width:100%;max-width:600px;height:300px;}button{margin:.25rem;}";
     page += "</style></head><body>";
     page += "<h1>Chauffe Piscine</h1>";
-    page += "<p>Eau: " + Utils::formatFloat(sensors->getWaterTemp()) + "&deg;C - Air: " + Utils::formatFloat(sensors->getAirTemp()) + "&deg;C - Chauffage: " + String(chauffage->isOn() ? "ON" : "OFF") + "</p>";
+    page += "<p>Eau: " + Utils::formatFloat(sensors->getWaterTemp()) + "&deg;C - Air: " + Utils::formatFloat(sensors->getAirTemp()) + "&deg;C</p>";
     page += "<form id='frm' action='/set' method='get'>";
     page += "<fieldset><legend>Mode</legend>";
     page += "<label><input type='radio' name='mode' value='MANUEL'";
@@ -42,14 +45,18 @@ void WebManager::handleRoot() {
     page += "<label><input type='radio' name='mode' value='AUTO'";
     if (chauffage->getMode() == ChauffageManager::AUTO) page += " checked";
     page += ">Auto</label></fieldset>";
-    page += "<div id='manual'><button type='button' id='forceOn'>Forcer ON</button> <button type='button' id='forceOff'>Forcer OFF</button></div>";
-    page += "<div id='auto'><label>Température cible:<input type='number' name='target' min='10' max='40' step='1' value='" + String((int)round(chauffage->getTargetTemp())) + "'></label></div>";
-    page += "<button type='submit'>Sauver</button></form>";
-    page += "<script>function update(){const m=document.querySelector('input[name=\"mode\"]:checked').value;document.getElementById('auto').style.display=m==='AUTO'?'block':'none';document.getElementById('manual').style.display=m==='MANUEL'?'block':'none';}";
-    page += "document.querySelectorAll('input[name=\"mode\"]').forEach(el=>el.addEventListener('change',update));";
-    page += "document.getElementById('forceOn').onclick=()=>location.href='/on';";
-    page += "document.getElementById('forceOff').onclick=()=>location.href='/off';";
-    page += "update();</script></body></html>";
+    page += "<div id='manualFields'><label><input type='radio' name='manuelEtat' value='ON'";
+    if (chauffage->isOn()) page += " checked";
+    page += ">Forcer ON</label><label><input type='radio' name='manuelEtat' value='OFF'";
+    if (!chauffage->isOn()) page += " checked";
+    page += ">Forcer OFF</label></div>";
+    page += "<div id='autoFields'><label>Température cible:<input type='number' name='tempCible' min='10' max='35' step='1' value='" + String((int)round(chauffage->getTargetTemp())) + "'></label></div>";
+    page += "<div id='scheduleOptions'><label><input type='checkbox' id='scheduleActive' name='plageActive'";
+    if (sch.enabled) page += " checked";
+    page += ">Activer plage horaire</label><div id='scheduleTimes'><label>Début:<input type='time' name='heureDebut' value='" + Utils::formatTime(sch.startHour, sch.startMin) + "'></label><label>Fin:<input type='time' name='heureFin' value='" + Utils::formatTime(sch.endHour, sch.endMin) + "'></label></div></div>";
+    page += "<button type='submit'>Appliquer</button></form>";
+    page += "<div><button id='v24'>Vue 24h</button><button id='v7'>Vue 7j</button></div><canvas id='chart'></canvas>";
+    page += "<script>function q(s){return document.querySelector(s);}function update(){var mode=q('input[name=mode]:checked').value;var manual=q('input[name=\\"manuelEtat\\"]:checked');var on=manual&&manual.value==='ON';q('#autoFields').style.display=mode==='AUTO'?'block':'none';q('#manualFields').style.display=mode==='MANUEL'?'block':'none';q('#scheduleOptions').style.display=(mode==='AUTO'||on)?'block':'none';toggleSchedule();}function toggleSchedule(){q('#scheduleTimes').style.display=q('#scheduleActive').checked?'block':'none';}document.querySelectorAll('input[name=mode]').forEach(e=>e.addEventListener('change',update));document.querySelectorAll('input[name=manuelEtat]').forEach(e=>e.addEventListener('change',update));q('#scheduleActive').addEventListener('change',toggleSchedule);update();let history=[],heating=[],chart;async function load(){const h=await fetch('/history.csv');const ht=await h.text();const c=await fetch('/chauffage.csv');const ct=await c.text();history=ht.trim().split('\n').slice(1).map(l=>{const p=l.split(',');return{t:new Date(p[0]),w:+p[1],a:+p[2]}});heating=ct.trim().split('\n').slice(1).map(l=>{const p=l.split(',');return{t:new Date(p[0]),on:p[1].trim()==='ON'}});const ctx=q('#chart').getContext('2d');chart=new Chart(ctx,{type:'line',data:{datasets:[{label:'Eau',borderColor:'blue',data:[],fill:false},{label:'Air',borderColor:'gray',data:[],fill:false},{label:'Chauffage',borderColor:'red',backgroundColor:'rgba(255,0,0,0.3)',data:[],stepped:true,fill:true,yAxisID:'y2'}]},options:{responsive:true,scales:{x:{type:'time'},y:{title:{display:true,text:'°C'}},y2:{display:false,min:0,max:1}}}});draw('24h');}function draw(r){const now=new Date();const from=new Date(now-(r==='24h'?86400000:604800000));const h=history.filter(e=>e.t>=from);const s=heating.filter(e=>e.t>=from);chart.data.datasets[0].data=h.map(e=>({x:e.t,y:e.w}));chart.data.datasets[1].data=h.map(e=>({x:e.t,y:e.a}));let d=[],state=0;d.push({x:from,y:0});for(const p of s){d.push({x:p.t,y:state});state=p.on?1:0;d.push({x:p.t,y:state});}d.push({x:now,y:state});chart.data.datasets[2].data=d;chart.update();}q('#v24').onclick=()=>draw('24h');q('#v7').onclick=()=>draw('7d');load();</script></body></html>";
     server.send(200, "text/html; charset=utf-8", page);
 }
 
@@ -59,18 +66,22 @@ void WebManager::handleSet() {
         if (m == "MANUEL") chauffage->setMode(ChauffageManager::MANUEL);
         else chauffage->setMode(ChauffageManager::AUTO);
     }
-    if (server.hasArg("target")) {
-        chauffage->setTargetTemp(server.arg("target").toFloat());
+    if (server.hasArg("tempCible")) {
+        chauffage->setTargetTemp(server.arg("tempCible").toFloat());
     }
     ChauffageManager::Schedule sch = chauffage->getSchedule();
-    sch.enabled = server.hasArg("schedule");
-    if (server.hasArg("start")) {
-        sscanf(server.arg("start").c_str(), "%2hhu:%2hhu", &sch.startHour, &sch.startMin);
+    sch.enabled = server.hasArg("plageActive");
+    if (server.hasArg("heureDebut")) {
+        sscanf(server.arg("heureDebut").c_str(), "%2hhu:%2hhu", &sch.startHour, &sch.startMin);
     }
-    if (server.hasArg("end")) {
-        sscanf(server.arg("end").c_str(), "%2hhu:%2hhu", &sch.endHour, &sch.endMin);
+    if (server.hasArg("heureFin")) {
+        sscanf(server.arg("heureFin").c_str(), "%2hhu:%2hhu", &sch.endHour, &sch.endMin);
     }
     chauffage->setSchedule(sch);
+    if (server.hasArg("manuelEtat")) {
+        if (server.arg("manuelEtat") == "ON") chauffage->manualOn();
+        else chauffage->manualOff();
+    }
     server.sendHeader("Location", "/", true);
     server.send(303, "text/plain", "");
 }


### PR DESCRIPTION
## Summary
- enhance HTML page with manual/auto options, schedule settings, and Chart.js graphs
- parse new GET parameters including `tempCible`, `plageActive`, `heureDebut`, `heureFin`, and `manuelEtat`

## Testing
- `pip install platformio`
- `pio run` *(fails: domain `api.registry.platformio.org` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867d5209fd883298aabdb4b06b3034a