### PR TITLE
Fix missing include

### DIFF
--- a/src/web.cpp
+++ b/src/web.cpp
@@ -4,6 +4,7 @@
 #include "FS.h"
 #include "SPIFFS.h"
 #include "utils.h"
+#include <functional>
 
 WebManager::WebManager(SensorsManager* sensorsRef, ChauffageManager* chauffageRef)
     : sensors(sensorsRef), chauffage(chauffageRef) {}


### PR DESCRIPTION
## Summary
- include `<functional>` in web module for `std::bind`

## Testing
- `platformio run -e esp32dev` *(fails: Platform Manager not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867d92438b48329ac450150d4562cf7