### PR TITLE
Add configurable servo positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Projet domotique open source basé sur ESP32 pour piloter automatiquement le cha
 
 ## 🔧 Configuration
 
-Les paramètres modifiables (Wi-Fi, broches GPIO, etc.) se trouvent dans `src/config.h`.
+Les paramètres modifiables (Wi-Fi, broches GPIO, positions du servo, etc.) se trouvent dans `src/config.h`.
 Avant de compiler, éditez ce fichier pour y renseigner votre SSID, mot de passe
 et éventuellement la température ou l'heure cible.
+Vous pouvez également ajuster `SERVO_POS_ON` et `SERVO_POS_OFF` pour adapter les angles d'activation du chauffage.
 
 Si vous utilisez VS Code avec PlatformIO, vous pouvez spécifier le port série à
 utiliser dans `platformio.ini` via les directives `upload_port` et

--- a/src/chauffage.cpp
+++ b/src/chauffage.cpp
@@ -5,6 +5,7 @@
 
 void ChauffageManager::begin() {
     servo.attach(PIN_SERVO);
+    servo.write(SERVO_POS_OFF);
 }
 
 void ChauffageManager::manualOn() {
@@ -29,7 +30,7 @@ bool ChauffageManager::withinSchedule(const tm& t) const {
 void ChauffageManager::applyHeating(bool on) {
     if (heating == on) return;
     heating = on;
-    servo.write(on ? 180 : 0);
+    servo.write(on ? SERVO_POS_ON : SERVO_POS_OFF);
     logState();
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -22,6 +22,10 @@ static constexpr StartMode DEFAULT_MODE = MODE_AUTO;
 static constexpr uint8_t PIN_SERVO = 14;      // Servo signal
 static constexpr uint8_t PIN_ONEWIRE = 4;     // DS18B20 bus
 
+// Servo positions (degrees)
+static constexpr uint8_t SERVO_POS_OFF = 0;   // Angle when heating is OFF
+static constexpr uint8_t SERVO_POS_ON  = 180; // Angle when heating is ON
+
 // Optional API key placeholder for future use
 static const char* API_KEY = "";
 


### PR DESCRIPTION
## Summary
- allow configuring servo angles in `config.h`
- use new constants in `ChauffageManager`
- document servo position settings in README

## Testing
- `platformio run` *(fails: domain not allowlisted)*

------
https://chatgpt.com/codex/tasks/task_e_686856822f7483299af6cd14bb93cae6