### PR TITLE
Adjust servo pulse range for SG90

### DIFF
--- a/src/chauffage.cpp
+++ b/src/chauffage.cpp
@@ -4,7 +4,8 @@
 #include "SPIFFS.h"
 
 void ChauffageManager::begin() {
-    servo.attach(PIN_SERVO);
+    // Use a standard 1-2 ms pulse range for better SG90 compatibility
+    servo.attach(PIN_SERVO, 1000, 2000);
     servo.write(SERVO_POS_OFF);
 }
 


### PR DESCRIPTION
## Summary
- use standard SG90 pulse range when attaching the servo

## Testing
- `platformio` not installed, so build tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_68685beb8d9c832996484c668c3e2d8c