### PR TITLE
Handle manual mode schedule bypass

### DIFF
--- a/src/chauffage.cpp
+++ b/src/chauffage.cpp
@@ -43,7 +43,7 @@ void ChauffageManager::update() {
     tm timeinfo;
     localtime_r(&raw, &timeinfo);
 
-    if (!withinSchedule(timeinfo)) {
+    if (mode != MANUEL && !withinSchedule(timeinfo)) {
         if (heating) applyHeating(false);
         return;
     }


### PR DESCRIPTION
## Summary
- skip schedule checks when in manual mode

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868686396448329af4cb09c1a9303e4